### PR TITLE
Cryptographically Secure Tripcodes

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -8,3 +8,4 @@ INCLUDE_DIR=../include
 TARGET=cchan
 LD=gcc
 LDFLAGS=
+LDLIBS=-lcrypto

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The fastest meme sharing ever.
 ## HOW TO
 ### COMPILE
 1. Make sure you are running an FSF-approved GNU/Linux distribution, or at the very least a libre \*BSD. If you still run botnet in $CURRENT_YEAR, just go to <https://gnu.org/distros/free-distros.html> and pick your freedom.
-2. C-chan currently only requires an C89 compatible standard library (any version of glibc will do), a proper C89 compatible compiler (I suggest the GNU C Compiler, also known as the GNU Compiler Collection), and the package make
+2. C-chan currently only requires an C89 compatible standard library (any version of glibc will do), a proper C89 compatible compiler (I suggest the GNU C Compiler, also known as the GNU Compiler Collection), the package make, and OpenSSL-dev (or your distro's equivalent package).
 3. Run "make"
 
 ### INSTALL

--- a/src/Makefile
+++ b/src/Makefile
@@ -10,7 +10,7 @@ all: $(TARGET)
 	mv $(TARGET) ..
 
 $(TARGET): $(DIRS) main.o
-	$(CC) $(LDFLAGS) $(OBJECTS) main.o -o $(TARGET)
+	$(CC) $(LDFLAGS) $(OBJECTS) main.o $(LDLIBS) -o $(TARGET)
 
 main.o:
 	$(CC) -o $@ -c main.c $(CFLAGS) -Iinclude/

--- a/src/engine/Makefile
+++ b/src/engine/Makefile
@@ -8,7 +8,7 @@ OBJECTS=$(SRC:.c=.o)
 all: $(OBJECTS)
 
 %.o: %.c
-	$(CC) $(CFLAGS) -c -I$(INCLUDE_DIR) $< -o $@
+	$(CC) $(CFLAGS) -c -I$(INCLUDE_DIR) $< $(LDLIBS) -o $@
 
 clean:
 	$(RM) -f $(OBJECTS)

--- a/src/engine/post.c
+++ b/src/engine/post.c
@@ -45,7 +45,6 @@ Post *new_post(char *title, char *name, char *txt, int id, int reply_to, int fla
         strncpy(post->name, "Anonymous", MAX_NAME_LENGTH);
     } else {
         parse_tripcode(name, post);
-	/*        strncpy(post->name, name, MAX_NAME_LENGTH); */
     }
     /* set title */
     post->title = malloc(sizeof(char) * MAX_TITLE_LENGTH);

--- a/src/engine/post.c
+++ b/src/engine/post.c
@@ -1,8 +1,40 @@
 #include <engine/post.h>
 
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+
+void parse_tripcode(const char *name, Post *post)
+{
+    int symbol_pos;
+    const char* secret;
+    char *srch = strpbrk(name, "#");
+    
+    /* Search for a # symbol.  If not found, there's no tripcode */
+    if(srch == NULL){
+	post->trip.hmac_size = 0;
+	post->trip.tripcode_hmac = NULL;
+        strncpy(post->name, name, MAX_NAME_LENGTH);
+	return;
+    }
+
+    /* Get the name part of the field */
+    symbol_pos = srch - name;
+    strncpy(post->name, name, symbol_pos);
+    post->name[symbol_pos] = '\0';
+
+    /*  Get everything ready to hash */
+    secret = name + symbol_pos + 1;
+    post->trip.tripcode_hmac = malloc(sizeof(unsigned char) * MAX_HMAC_LENGTH);
+
+    /* Compute the HMAC using SHA512 */
+    HMAC(EVP_sha512(), secret, strlen(secret), (unsigned char *) post->name, strlen(post->name), post->trip.tripcode_hmac, &(post->trip.hmac_size));
+    
+    return;    
+}
 
 Post *new_post(char *title, char *name, char *txt, int id, int reply_to, int flags)
 {
@@ -12,7 +44,8 @@ Post *new_post(char *title, char *name, char *txt, int id, int reply_to, int fla
     if (name == NULL) { /* set "Anonymous" as a name */
         strncpy(post->name, "Anonymous", MAX_NAME_LENGTH);
     } else {
-        strncpy(post->name, name, MAX_NAME_LENGTH);
+        parse_tripcode(name, post);
+	/*        strncpy(post->name, name, MAX_NAME_LENGTH); */
     }
     /* set title */
     post->title = malloc(sizeof(char) * MAX_TITLE_LENGTH);
@@ -55,6 +88,9 @@ Post *new_post(char *title, char *name, char *txt, int id, int reply_to, int fla
 
 void free_post(Post *post)
 {
+    if(post->trip.hmac_size)
+	free(post->trip.tripcode_hmac);
+    
     free(post->txt);
     free(post->name);
     free(post->title);

--- a/src/include/engine/post.h
+++ b/src/include/engine/post.h
@@ -9,16 +9,23 @@
 static const unsigned int MAX_POST_LENGTH = 2048;
 static const unsigned int MAX_NAME_LENGTH = 128;
 static const unsigned int MAX_TITLE_LENGTH = 128;
+static const unsigned int MAX_HMAC_LENGTH = 64;
+
+typedef struct {
+    unsigned char *tripcode_hmac;
+    unsigned int hmac_size;
+} Tripcode;
 
 typedef struct {
     int is_op;
-    char *name;  /* field 0 */
-    char *title; /* field 1 */
-    char *txt;   /* field 2 */
+    char *name;    /* field 0 */
+    char *title;   /* field 1 */
+    char *txt;     /* field 2 */
     int len;
-    int id;      /* field 3 */
-    int reply_to;/* field 4 */
-    int flags;   /* field 5 */
+    int id;        /* field 3 */
+    int reply_to;  /* field 4 */
+    int flags;     /* field 5 */
+    Tripcode trip;
 } Post;
 
 Post* new_post(char *title, char *name, char *txt, int id, int reply_to, int flags);

--- a/src/tests/Makefile
+++ b/src/tests/Makefile
@@ -10,4 +10,3 @@ all: $(OBJECTS)
 
 clean:
 	$(RM) -f $(OBJECTS)
-

--- a/src/tests/posts.c
+++ b/src/tests/posts.c
@@ -1,4 +1,7 @@
 #include <engine/post.h>
+#include <tests/pot.h>
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -7,14 +10,24 @@
 
 int test_create_post(void* data)
 {
-    (void) data;
-    int status = 1;
+    int status;
+    int iter;
+    unsigned int h_size;
+    unsigned char *known_vect;
+    unsigned char *name;
+    unsigned char *pword;
     Post *post = new_post("title", "name", "text", 1, 2, 0);
+    status = 1;
+    (void) data;
+    name = (unsigned char *) "name";
+    pword = (unsigned char *) "password";
     /* Make sure fields have been set correctly */
     assert(strcmp(post->title, "title") == 0);
     assert(strcmp(post->name, "name") == 0);
     assert(strcmp(post->txt, "text") == 0);
     assert(post->reply_to == 2);
+    assert(post->trip.tripcode_hmac == NULL);
+    assert(post->trip.hmac_size == 0);
     /* Make sure fields have been guessed correctly */
     assert(! post->is_op);
     assert(post->len == strlen("text"));
@@ -28,6 +41,8 @@ int test_create_post(void* data)
     assert(post->reply_to == 2);
     assert(! post->is_op);
     assert(post->len == strlen("text"));
+    assert(post->trip.tripcode_hmac == NULL);
+    assert(post->trip.hmac_size == 0);
     free_post(post);
     /* Create an OP post */
     post = new_post("title", "name", "text", 1, -1, 0);
@@ -38,6 +53,26 @@ int test_create_post(void* data)
     assert(post->reply_to == -1);
     assert(post->is_op);
     assert(post->len == strlen("text"));
+    assert(post->trip.tripcode_hmac == NULL);
+    assert(post->trip.hmac_size == 0);
+    free_post(post);
+    /* Create a post with a tripcode */
+    post = new_post("title", "name#password", "text", 1, 2, 0);
+    assert(strcmp(post->name, "name") == 0);
+    assert(strcmp(post->title, "title") == 0);
+    assert(strcmp(post->txt, "text") == 0);
+    assert(post->id == 1);
+    assert(post->reply_to == 2);
+    assert(! post->is_op);
+    assert(post->len == strlen("text"));
+    assert(post->trip.tripcode_hmac != NULL);
+    
+    known_vect = HMAC(EVP_sha512(), pword, 8, name, 4, NULL, &h_size);
+      
+    assert(post->trip.hmac_size == h_size);
+    for(iter = 0; iter != 64; ++iter){
+      assert(post->trip.tripcode_hmac[iter] == known_vect[iter]);
+    }
     free_post(post);
     return status;
 }


### PR DESCRIPTION
Currently, chans have no cryptographically secure tripcodes.  They rely on outdated algorithms that are easy to brute force and find collisions on.  To that end, I've added cryptographically secure tripcodes here.  

My tripcodes use OpenSSL's implementation of a SHA-512 HMAC.  HMACs require a key and a message.  In the case here, if the user enters "name#password" in the name field, their tripcode will be computed by HMAC-SHA512(key="password", message="name").  This system is only as strong as the password that generates it though, so users should still use strong passwords.

Posts now also have a tripcode struct as a part of them, containing the tripcode (if any) and the length of that tripcode.  I have also added to the test suites so that they test for tripcode functionality.  Also note that because the tripcodes use OpenSSL's hash functions, building the project now requires openssl-dev (or your distro's equivalent package).